### PR TITLE
transfer repo and fixed unknown command status bug and improve test

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,5 +14,5 @@ archives:
     name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
 release:
   github:
-    owner: kazeburo
+    owner: monitoring-forge
     name: mackerel-plugin-command-status

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 VERSION=0.0.4
-LDFLAGS=-ldflags "-w -s -X main.version=${VERSION} "
+GITCOMMIT?=$(shell git describe --dirty --always)
+LDFLAGS=-ldflags "-w -s -X main.version=${VERSION} -X main.commit=${GITCOMMIT}"
 
 all: mackerel-plugin-command-status
 
@@ -12,12 +13,4 @@ linux: main.go
 	GOOS=linux GOARCH=amd64 go build $(LDFLAGS) -o mackerel-plugin-command-status main.go
 
 check:
-	go test ./...
-
-fmt:
-	go fmt ./...
-
-tag:
-	git tag v${VERSION}
-	git push origin v${VERSION}
-	git push origin master
+	go test -v ./...

--- a/README.md
+++ b/README.md
@@ -56,4 +56,4 @@ and set a monitor with `warning(critical)  > 0` and `maxCheckAttempts` appropria
 
 ## Install
 
-Please download release page or `mkr plugin install kazeburo/mackerel-plugin-command-status`.
+Please download release page or `mkr plugin install monitoring-forge/mackerel-plugin-command-status`.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/kazeburo/mackerel-plugin-command-status
+module github.com/monitoring-forge/mackerel-plugin-command-status
 
 go 1.25.0
 

--- a/main.go
+++ b/main.go
@@ -6,53 +6,67 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"time"
 
 	"github.com/jessevdk/go-flags"
 )
 
-// Version by Makefile
 var version string
+var commit string
 
-type opts struct {
-	OptArgs    []string
-	OptCommand string
-	Timeout    time.Duration `long:"timeout" default:"30s" description:"Timeout to wait for command finished"`
-	Name       string        `short:"n" long:"name" description:"Metrics name" required:"true"`
-	Quiet      bool          `short:"q" long:"quiet" description:"Suppress error output of sub command"`
-	Version    bool          `short:"v" long:"version" description:"Show version"`
+const (
+	TimeoutStatus        = 137
+	UnknownCommandStatus = 127
+)
+
+type Opt struct {
+	Args    []string
+	Command string
+	Timeout time.Duration `long:"timeout" default:"30s" description:"Timeout to wait for command finished"`
+	Name    string        `short:"n" long:"name" description:"Metrics name" required:"true"`
+	Quiet   bool          `short:"q" long:"quiet" description:"Suppress error output of sub command"`
+	Version bool          `short:"v" long:"version" description:"Show version"`
 }
 
-func runCmd(opts opts) int {
-	now := time.Now().Unix()
+func (opt *Opt) cmd() (int, time.Duration) {
 	start := time.Now()
-	cmd := exec.Command(opts.OptCommand, opts.OptArgs...)
+	cmd := exec.Command(opt.Command, opt.Args...)
 	cmd.Stdout = os.Stderr
 	cmd.Start()
 	done := make(chan error)
 	go func() { done <- cmd.Wait() }()
-	ctx, cancel := context.WithTimeout(context.Background(), opts.Timeout)
+	ctx, cancel := context.WithTimeout(context.Background(), opt.Timeout)
 	defer cancel()
 	var status int
 	select {
 	case <-ctx.Done():
 		cmd.Process.Kill()
-		if !opts.Quiet {
-			log.Printf("Command %s timeout. killed", opts.OptCommand)
+		if !opt.Quiet {
+			log.Printf("Command %s timeout. killed", opt.Command)
 		}
-		status = 137
+		status = TimeoutStatus
 	case err := <-done:
 		if err != nil {
-			if !opts.Quiet {
-				log.Printf("Command %s exit with err: %v", opts.OptCommand, err)
+			if !opt.Quiet {
+				log.Printf("Command %s exit with err: %v", opt.Command, err)
 			}
 		}
 		status = cmd.ProcessState.ExitCode()
 	}
 	duration := time.Since(start)
-	fmt.Printf("command-status.time-taken.%s\t%f\t%d\n", opts.Name, duration.Seconds(), now)
-	fmt.Printf("command-status.exit-code.%s\t%d\t%d\n", opts.Name, status, now)
+	if status < 0 {
+		status = UnknownCommandStatus
+	}
+	return status, duration
+}
+
+func (opt *Opt) run() int {
+	now := time.Now().Unix()
+	status, duration := opt.cmd()
+	fmt.Printf("command-status.time-taken.%s\t%f\t%d\n", opt.Name, duration.Seconds(), now)
+	fmt.Printf("command-status.exit-code.%s\t%d\t%d\n", opt.Name, status, now)
 	return 0
 }
 
@@ -61,29 +75,36 @@ func main() {
 }
 
 func _main() int {
-	opts := opts{}
-	psr := flags.NewParser(&opts, flags.HelpFlag|flags.PassDoubleDash)
+	opt := &Opt{}
+	psr := flags.NewParser(opt, flags.HelpFlag|flags.PassDoubleDash)
 	psr.Usage = "mackerel-plugin-command-status [OPTIONS] -- command args1 args2 ..."
 	args, err := psr.Parse()
-	if opts.Version {
-		fmt.Fprintf(os.Stderr, "Version: %s\nCompiler: %s %s\n",
+	if opt.Version {
+		if commit == "" {
+			commit = "dev"
+		}
+		fmt.Printf(
+			"%s-%s\n%s/%s, %s, %s\n",
+			filepath.Base(os.Args[0]),
 			version,
-			runtime.Compiler,
-			runtime.Version())
-		os.Exit(0)
+			runtime.GOOS,
+			runtime.GOARCH,
+			runtime.Version(),
+			commit)
+		return 0
 	}
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
-		os.Exit(1)
+		return 1
 	}
 	if len(args) == 0 {
 		psr.WriteHelp(os.Stderr)
-		os.Exit(1)
+		return 1
 	}
-	opts.OptCommand = args[0]
+	opt.Command = args[0]
 	if len(args) > 1 {
-		opts.OptArgs = args[1:]
+		opt.Args = args[1:]
 	}
 
-	return runCmd(opts)
+	return opt.run()
 }

--- a/main.go
+++ b/main.go
@@ -34,8 +34,13 @@ func (opt *Opt) cmd() (int, time.Duration) {
 	start := time.Now()
 	cmd := exec.Command(opt.Command, opt.Args...)
 	cmd.Stdout = os.Stderr
-	cmd.Start()
-	done := make(chan error)
+	if err := cmd.Start(); err != nil {
+		if !opt.Quiet {
+			log.Printf("Command %s exit with err: %v", opt.Command, err)
+		}
+		return UnknownCommandStatus, time.Since(start)
+	}
+	done := make(chan error, 1)
 	go func() { done <- cmd.Wait() }()
 	ctx, cancel := context.WithTimeout(context.Background(), opt.Timeout)
 	defer cancel()

--- a/main_test.go
+++ b/main_test.go
@@ -43,3 +43,16 @@ func TestCmdUnknownCommand(t *testing.T) {
 		t.Fatalf("Expected non-zero exit code for unknown command, got %d", status)
 	}
 }
+
+func TestCmdTimeout(t *testing.T) {
+	opt := Opt{
+		Command: "sleep",
+		Args:    []string{"10"},
+		Timeout: 100 * time.Millisecond,
+	}
+
+	status, _ := opt.cmd()
+	if status != TimeoutStatus {
+		t.Fatalf("Expected timeout status %d, got %d", TimeoutStatus, status)
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestCmd(t *testing.T) {
+	// Test command execution
+	cmd := "echo"
+	args := []string{"Hello, World!"}
+	timeout := 5 * time.Second
+
+	opt := Opt{
+		Command: cmd,
+		Args:    args,
+		Timeout: timeout,
+	}
+
+	status, duration := opt.cmd()
+	if status != 0 {
+		t.Fatalf("Expected exit code 0, got %d", status)
+	}
+	if duration <= 0 {
+		t.Fatalf("Expected duration greater than 0, got %v", duration)
+	}
+}
+
+// Test with unknown command to ensure it returns a non-zero exit code
+func TestCmdUnknownCommand(t *testing.T) {
+	cmd := "unknown_command"
+	args := []string{}
+	timeout := 5 * time.Second
+
+	opt := Opt{
+		Command: cmd,
+		Args:    args,
+		Timeout: timeout,
+	}
+
+	status, _ := opt.cmd()
+	if status != UnknownCommandStatus {
+		t.Fatalf("Expected non-zero exit code for unknown command, got %d", status)
+	}
+}


### PR DESCRIPTION
This pull request migrates the project repository from `kazeburo` to `monitoring-forge`, improves versioning and build metadata, refactors the main code for better structure and error handling, and adds tests for command execution. The most important changes are summarized below:

**Repository migration and metadata updates:**
* Changed all project references from `kazeburo` to `monitoring-forge`, including `go.mod`, `.goreleaser.yml`, and documentation in `README.md`. [[1]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L1-R1) [[2]](diffhunk://#diff-42e26dc67aed8aa3edb2472b4403288c1699fb6dc47419b9a475f0f224fe4689L17-R17) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L59-R59)

**Build and versioning improvements:**
* Enhanced the `Makefile` to inject both version and git commit hash into the binary for better traceability.
* Updated the version output to include the binary name, version, OS/Arch, Go version, and commit hash.

**Code refactoring and enhancements:**
* Refactored the main logic in `main.go` for improved structure: consolidated command execution into the `Opt` struct, improved timeout and error handling, and introduced constants for exit codes. [[1]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R9-R69) [[2]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L64-R109)
* Improved test command output with more verbose test execution in the `Makefile`.

**Testing:**
* Added `main_test.go` with unit tests for command execution, including normal and error scenarios.